### PR TITLE
[Suggestion] Make the ship react more to the reactor meltdown

### DIFF
--- a/FacilityMeltdown/MeltdownSequence/Behaviours/FacilityExplosionHandler.cs
+++ b/FacilityMeltdown/MeltdownSequence/Behaviours/FacilityExplosionHandler.cs
@@ -75,7 +75,8 @@ namespace FacilityMeltdown.MeltdownSequence.Behaviours
 
         bool ShouldIgnorePlayer()
         {
-            return player.isPlayerDead || player.isInElevator && StartOfRound.Instance.shipIsLeaving;
+            return player.isPlayerDead || (!MeltdownPlugin.config.ENABLE_SHIP_MALFUNCTION &&
+                                           player.isInElevator && StartOfRound.Instance.shipIsLeaving);
         }
 
         float TimeToSize(float time)

--- a/FacilityMeltdown/Util/MeltdownConfig.cs
+++ b/FacilityMeltdown/Util/MeltdownConfig.cs
@@ -24,7 +24,7 @@ namespace FacilityMeltdown.Util {
         [DataMember]
         internal SyncedEntry<int> MONSTER_SPAWN_AMOUNT, APPARATUS_VALUE, MELTDOWN_TIME;
         [DataMember]
-        internal SyncedEntry<bool> OVERRIDE_APPARATUS_VALUE, EMERGENCY_LIGHTS;
+        internal SyncedEntry<bool> OVERRIDE_APPARATUS_VALUE, EMERGENCY_LIGHTS, ENABLE_SHIP_MALFUNCTION;
         [DataMember]
         internal SyncedEntry<float> SCAN_COOLDOWN, SCAN_ACCURACY;
         
@@ -46,7 +46,8 @@ namespace FacilityMeltdown.Util {
             APPARATUS_VALUE = file.BindSyncedEntry("GameBalance", "AppartusValue", 240, "What the value of the appartus should be set as IF override appartus value is `true`");
             MONSTER_SPAWN_AMOUNT = file.BindSyncedEntry("GameBalance", "MonsterSpawnAmount", 5, "How many monsters should spawn during the meltdown sequence? Set to 0 to disable.");
             EMERGENCY_LIGHTS = file.BindSyncedEntry("GameBalance", "EmergencyLights", true, "Should the lights turn on periodically? Disabling this option makes them permanently off. (Matches Vanilla Behaviour)");
-
+            ENABLE_SHIP_MALFUNCTION = file.BindSyncedEntry("GameBalance", "ShipMalfunction", false, "Should the ship panic during the meltdown sequence? Lights, shipdoor, screens, and even the lever will start to bug as the reactor core gets more and more unstable");
+            
             DISALLOWED_ENEMIES = file.BindSyncedEntry("GameBalance", "DisallowedEnemies", "Centipede,Hoarding bug", "What enemies to exclude from spawning in the meltdown sequence. Comma seperated list. \"Should\" support modded entities");
 
             MELTDOWN_TIME = file.BindSyncedEntry("Unsupported", "MeltdownTime", 120, "ABSOLUETLY NOT SUPPORTED OR RECOMMENDED! Change the length of the meltdown sequence. If this breaks I am not fixing it, you have been warned.");


### PR DESCRIPTION
Hi,

I had a few ideas to add to your mod. The main one was : what if the ship did not automatically take off when the nuclear explosion occured ?
So, I open this pull request to share this idea. Below is listed the commit message that explains what I have changed. Also, here is an unlisted [video](https://www.youtube.com/watch?v=2S9tTRHnpj4) showing the effects I added. The changes are compatible with both v49 and v50, assuming the mod has been compiled with the proper version of the game.

-Once the meltdown starts, all ship lights (including roof ones) turn to red, and start blinking (if enabled in config). The less time remains before the explosion, the faster they blink.
-Door control cease to function. From time to time (each 10s actually), the doors are toggled
-30s before the explosion, some screens and the door power display die.
-3s before the explosion, the lever used to take off cease to function :)    (of course, the ship won't take off on its own)
-Players are no longer safe inside the ship : if they are hit by the shockwave inside the ship, they'll die

All these effects are only applied if the new config entry ENABLE_SHIP_MALFUNCTION is set to true. If it is left to false (default), the mod behaves normally

