### PR TITLE
Update WeatherRegistryIntegration

### DIFF
--- a/FacilityMeltdown/Integrations/WeatherRegistryIntegration.cs
+++ b/FacilityMeltdown/Integrations/WeatherRegistryIntegration.cs
@@ -1,16 +1,16 @@
 ﻿using System.Runtime.CompilerServices;
+using BepInEx.Bootstrap;
 using FacilityMeltdown.Config;
 using WeatherRegistry;
 
 namespace FacilityMeltdown.Integrations;
 
 class WeatherRegistryIntegration {
-	public static bool Enabled { get; private set; } // If you want to check compatibility locally
+	public static bool Enabled => Chainloader.PluginInfos.ContainsKey("mrov.WeatherRegistry");
 	
 	// This method will be called automatically if the compatible mod is loaded.
 	[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
 	static void Initialize() {
-		Enabled = true;
 	}
 
 	[MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]


### PR DESCRIPTION
This PR aims to fix an issue I've discover when debugging an issue between `WeatherRegistry`, `FacilityMeltdown` and `Imperium` (this was reported [in WeatherRegistry thread](https://discord.com/channels/1168655651455639582/1203871322841808906/1322248942192169062)):

I've used combination of those mods to debug the issue:
- when 3 were installed, the scrap mutiplier was applied correctly
- when `Imperium` and `WeatherRegistry` were installed, the scrap mutiplier was applied correctly
- when `Imperium` and `FacilityMeltdown` were installed, the override was correctly applied (since there weren't any multipliers)
- when `WeatherRegistry` and `FacilityMeltdown` were installed, the scrap mutiplier was **not applied correctly**

After debugging for a while, I've found that `WeatherRegistryIntegration.Initialize()` https://github.com/LoafOrc/FacilityMeltdown/blob/74a2b8f0ecd190d1420e40c840c77a124518a3f9/FacilityMeltdown/Integrations/WeatherRegistryIntegration.cs#L10-L14 is not called at any point, _treating WeatherRegistry as disabled/inactive/not present._

My proposed fix is to **always** perform a Chainloader lookup to determine if the mod is present.